### PR TITLE
Handle empty data in SolcastForecastChart gracefully

### DIFF
--- a/app/Filament/Widgets/SolcastForecastChart.php
+++ b/app/Filament/Widgets/SolcastForecastChart.php
@@ -23,6 +23,11 @@ class SolcastForecastChart extends ChartWidget
     {
         $rawData = $this->getDatabaseData();
 
+        if ($rawData->count() === 0) {
+            self::$heading = 'No data for Solis forecast';
+            return [];
+        }
+
         self::$heading = sprintf('Solis forecast for %s to %s (last updated %s)',
             Carbon::parse($rawData->first()['period_end'], 'UTC')
                 ->timezone('Europe/London')


### PR DESCRIPTION
Add a check for empty data in SolcastForecastChart to prevent errors. Updates the heading accordingly and returns an empty array when no data is available. This ensures a better user experience and avoids potential crashes.