### PR TITLE
Add `battery_soc` to upsert update fields in InverterImport

### DIFF
--- a/app/Imports/InverterImport.php
+++ b/app/Imports/InverterImport.php
@@ -105,7 +105,7 @@ class InverterImport implements ToCollection, WithHeadingRow
         Inverter::upsert(
             $data,
             uniqueBy: ['period'],
-            update: ['yield', 'to_grid', 'from_grid', 'consumption']
+            update: ['yield', 'to_grid', 'from_grid', 'consumption', 'battery_soc']
         );
     }
 


### PR DESCRIPTION
Include `battery_soc` in the list of fields to update during the upsert operation. This ensures the state of charge for batteries is properly tracked and updated in the database.