### PR TITLE
Add CostChart widget for visualizing strategy costs

### DIFF
--- a/app/Filament/Resources/StrategyResource.php
+++ b/app/Filament/Resources/StrategyResource.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\StrategyResource\Action\CalculateBatteryAction;
 use App\Filament\Resources\StrategyResource\Action\CopyConsumptionWeekAgoAction;
 use App\Filament\Resources\StrategyResource\Action\GenerateAction;
 use App\Filament\Resources\StrategyResource\Pages;
+use App\Filament\Resources\StrategyResource\Widgets\CostChart;
 use App\Filament\Resources\StrategyResource\Widgets\StrategyChart;
 use App\Filament\Resources\StrategyResource\Widgets\StrategyOverview;
 use App\Models\Strategy;
@@ -211,6 +212,7 @@ class StrategyResource extends Resource
         return [
             StrategyOverview::class,
             StrategyChart::class,
+            CostChart::class,
         ];
     }
 

--- a/app/Filament/Resources/StrategyResource/Pages/ListStrategies.php
+++ b/app/Filament/Resources/StrategyResource/Pages/ListStrategies.php
@@ -3,9 +3,9 @@
 namespace App\Filament\Resources\StrategyResource\Pages;
 
 use App\Filament\Resources\StrategyResource;
+use App\Filament\Resources\StrategyResource\Widgets\CostChart;
 use App\Filament\Resources\StrategyResource\Widgets\StrategyChart;
 use App\Filament\Resources\StrategyResource\Widgets\StrategyOverview;
-use App\Filament\Resources\StrategyResource\Widgets\StrategyWidget;
 use Filament\Actions;
 use Filament\Pages\Concerns\ExposesTableToWidgets;
 use Filament\Resources\Pages\ListRecords;
@@ -28,6 +28,7 @@ class ListStrategies extends ListRecords
         return [
             StrategyOverview::class,
             StrategyChart::class,
+            CostChart::class,
         ];
     }
 }

--- a/app/Filament/Resources/StrategyResource/Widgets/CostChart.php
+++ b/app/Filament/Resources/StrategyResource/Widgets/CostChart.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Filament\Resources\StrategyResource\Widgets;
+
+use App\Filament\Resources\StrategyResource\Pages\ListStrategies;
+use Filament\Widgets\ChartWidget;
+use Filament\Widgets\Concerns\InteractsWithPageTable;
+use Illuminate\Support\Carbon;
+
+class CostChart extends ChartWidget
+{
+    use InteractsWithPageTable;
+
+    protected int|string|array $columnSpan = 2;
+
+    protected static ?string $maxHeight = '400px';
+
+    protected static ?string $heading = 'Agile forecast cost';
+    protected static ?string $pollingInterval = '120s';
+
+    /**
+     * @var int|mixed
+     */
+    public float $minValue = 0.0;
+
+
+    protected function getData(): array
+    {
+        $data = $this->getDatabaseData();
+
+        self::$heading = sprintf('Agile costs from %s to %s',
+            Carbon::parse($data->first()['valid_from'], 'UTC')
+                ->timezone('Europe/London')
+                ->format('D jS M Y H:i'),
+            Carbon::parse($data->last()['valid_from'], 'UTC')
+                ->timezone('Europe/London')
+                ->format('jS M H:i'),
+        );
+
+        $averageExport = $data->sum('export_value_inc_vat') / $data->count();
+        $averageImport = $data->sum('import_value_inc_vat') / $data->count();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Export value',
+                    'data' => $data->map(fn($item): string => $item['export_value_inc_vat']),
+                    'fill' => true,
+                    'backgroundColor' => 'rgba(75, 192, 192, 0.2)',
+                    'borderColor' => 'rgb(75, 192, 192)',
+                    'stepped' => 'middle',
+                ],
+                [
+                    'label' => 'Import value',
+                    'data' => $data->map(fn($item): string => $item['import_value_inc_vat']),
+                    'fill' => '-1',
+                    'backgroundColor' => 'rgba(255, 99, 132, 0.2)',
+                    'borderColor' => 'rgb(255, 99, 132)',
+                    'stepped' => 'middle',
+                ],
+                [
+                    'label' => sprintf('Average export value (%0.02f)', $averageExport),
+                    'data' => $data->map(fn($item): string => number_format($averageExport, 2)),
+                    'type' => 'line',
+                    'borderDash' => [5, 10],
+                    'pointRadius' => 0,
+                    'borderColor' => 'rgb(75, 192, 192)',
+                ],
+
+                [
+                    'label' => sprintf('Average import value (%0.02f)', $averageImport),
+                    'data' => $data->map(fn($item): string => number_format($averageImport, 2)),
+                    'borderDash' => [5, 10],
+                    'type' => 'line',
+                    'pointRadius' => 0,
+                    'borderColor' => 'rgb(255, 99, 132)',
+                ]
+            ],
+            'labels' => $data->map(function ($item): string {
+                $date = Carbon::parse($item['valid_from'], 'UTC')
+                    ->timezone('Europe/London');
+
+                $format = $date->format('H:i') === '00:00' ? 'j M H:i' : 'H:i';
+
+                return $date->format($format);
+            }),
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+
+    private function getDatabaseData()
+    {
+
+        $tableData = $this->getPageTableRecords();
+        $data = [];
+
+        foreach ($tableData as $strategy) {
+            $data[] = [
+                'valid_from' => $strategy->period,
+                'import_value_inc_vat' => $strategy->import_value_inc_vat,
+                'export_value_inc_vat' => $strategy->export_value_inc_vat,
+            ];
+        }
+
+        return collect($data);
+    }
+
+    protected function getTablePage(): string
+    {
+        return ListStrategies::class;
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            'scales' => [
+                'y' => [
+                    'type' => 'linear',
+                    'min' => $this->minValue,
+                ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Introduce a new `CostChart` widget that displays agile forecast cost data, including export and import values with averages. Integrate the widget into the `StrategyResource` and `ListStrategies` pages to enhance data visualization.