### PR TITLE
Fix timezone inconsistencies by standardising to UTC

### DIFF
--- a/app/Filament/Resources/StrategyResource.php
+++ b/app/Filament/Resources/StrategyResource.php
@@ -174,9 +174,9 @@ class StrategyResource extends Resource
 
                         if (isset($data['value'])) {
                             $start = Carbon::parse($data['value'], 'Europe/London')
-                                ->startOfDay();
+                                ->startOfDay()->timezone('UTC');
                             $end = Carbon::parse($data['value'], 'Europe/London')
-                                ->endOfDay();
+                                ->endOfDay()->timezone('UTC');
                             $query->whereBetween('period', [$start, $end]);
                         }
                     })

--- a/app/Filament/Resources/StrategyResource/Widgets/ElectricImportExportChart.php
+++ b/app/Filament/Resources/StrategyResource/Widgets/ElectricImportExportChart.php
@@ -33,11 +33,11 @@ class ElectricImportExportChart extends ChartWidget
         }
 
         self::$heading = sprintf('Actual electric export and import from %s to %s cost £%0.2f',
-            Carbon::parse($rawData->first()['interval_start'], 'UTC')
-                ->timezone('Europe/London')
+            Carbon::parse($rawData->first()['interval_start'], 'London/Europe')
+                ->timezone('UTC')
                 ->format('D jS M Y H:i'),
-            Carbon::parse($rawData->last()['interval_end'], 'UTC')
-                ->timezone('Europe/London')
+            Carbon::parse($rawData->last()['interval_end'], 'London/Europe')
+                ->timezone('UTC')
                 ->format('jS M H:i'),
             -$rawData->last()['net_accumulative_cost']
         );
@@ -102,7 +102,7 @@ class ElectricImportExportChart extends ChartWidget
     private function getDatabaseData(): Collection
     {
         $date = $this->tableFilters['period']['value'] ?? now('Europe/London')->format('Y-m-d');
-        $start = Carbon::parse($date, 'Europe/London')->startOfDay();
+        $start = Carbon::parse($date, 'Europe/London')->startOfDay()->timezone('UTC');
 
         $limit = 48;
 
@@ -115,7 +115,7 @@ class ElectricImportExportChart extends ChartWidget
             ->where(
                 'interval_start',
                 '<=',
-                $start->copy()->timezone('Europe/London')->endOfDay()
+                $start->copy()->timezone('Europe/London')->endOfDay()->timezone('UTC')
             )
             ->orderBy('interval_start')
             ->limit($limit)


### PR DESCRIPTION
Updated all date and time parsing to consistently use UTC timezone, ensuring uniformity and preventing potential errors caused by mismatched timezones. This improves data accuracy when handling import/export intervals.