### PR TITLE
Add handling for negative values in StrategyChart and AgileChart

### DIFF
--- a/app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
+++ b/app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
@@ -16,6 +16,11 @@ class StrategyChart extends ChartWidget
 
     protected static ?string $heading = 'Manual charge strategy';
 
+    /**
+     * @var float The minimum value for the chart's y-axis
+     */
+    protected float $minValue = 0.0;
+
     protected function getData(): array
     {
         $rawData = $this->getDatabaseData();
@@ -95,13 +100,13 @@ class StrategyChart extends ChartWidget
 
     private function getDatabaseData(): Collection
     {
-
         $tableData = $this->getPageTableRecords();
 
         $accumulativeCost = 0;
         $exportAccumulativeCost = 0;
         $importAccumulativeCost = 0;
         $data = [];
+        $minCost = 0;
 
         foreach ($tableData as $strategy) {
             $import = $strategy->import_amount + $strategy->battery_charge_amount;
@@ -116,6 +121,9 @@ class StrategyChart extends ChartWidget
             $importAccumulativeCost += $importCost;
             $exportAccumulativeCost += $exportCost;
 
+            // Track the minimum cost value
+            $minCost = min($minCost, $cost, $accumulativeCost, -$exportAccumulativeCost);
+
             $data[] = [
                 'period_end' => $strategy->period,
                 'import' => $import,
@@ -128,6 +136,18 @@ class StrategyChart extends ChartWidget
                 'export_accumulative_cost' => $exportAccumulativeCost,
 
             ];
+        }
+
+        // Calculate the minimum value for the chart
+        if ($minCost < 0) {
+            // Round negative values to the nearest -5
+            // For example: -3 becomes -5, -7 becomes -10, -12 becomes -15
+            // This ensures that the chart displays negative values correctly
+            // and maintains consistency with the Agile cost chart
+            $this->minValue = floor($minCost / 5) * 5;
+        } else {
+            // If there are no negative values, use 0 as the minimum
+            $this->minValue = 0;
         }
 
         return collect($data);
@@ -146,11 +166,13 @@ class StrategyChart extends ChartWidget
                     'type' => 'linear',
                     'display' => true,
                     'position' => 'left',
+                    'min' => $this->minValue,
                 ],
                 'y1' => [
                     'type' => 'linear',
                     'display' => true,
                     'position' => 'right',
+                    'min' => 0, // Battery percentage should not go below 0
 
                     // grid line settings
                     'grid' => [
@@ -162,6 +184,7 @@ class StrategyChart extends ChartWidget
                     'type' => 'linear',
                     'display' => true,
                     'position' => 'right',
+                    'min' => $this->minValue,
 
                     // grid line settings
                     'grid' => [

--- a/app/Filament/Widgets/AgileChart.php
+++ b/app/Filament/Widgets/AgileChart.php
@@ -24,7 +24,7 @@ class AgileChart extends ChartWidget
     protected static ?string $pollingInterval = '120s';
 
     /**
-     * @var int|mixed
+     * @var float The minimum value for the chart's y-axis
      */
     public float $minValue = 0.0;
 
@@ -158,10 +158,14 @@ class AgileChart extends ChartWidget
             ->limit($limit)
             ->get();
 
-        // get min for value_inc_vat, including some space
         $min = floor($importData->min('value_inc_vat') ?? 1) - 1;
-        // use a negative value or set to 0
-        $this->minValue = min($min, 0);
+
+        if ($min < 0) {
+            $this->minValue = floor($min / 5) * 5;
+        } else {
+            // If there are no negative values, use 0 as the minimum
+            $this->minValue = 0;
+        }
 
         // combine the data for the chart
         return $importData->map(fn($item) => [

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -5,22 +5,22 @@ The strategy chart currently has a hard-coded minimum of 0. If any costs are bel
 
 ## Tasks
 
-1. [ ] **Analysis and Understanding**
-   - [ ] Review the current StrategyChart implementation in `app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php`
-   - [ ] Examine how the Agile cost chart (`app/Filament/Widgets/AgileChart.php`) handles negative values
-   - [ ] Identify all places where chart minimum values are set
+1. [x] **Analysis and Understanding**
+   - [x] Review the current StrategyChart implementation in `app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php`
+   - [x] Examine how the Agile cost chart (`app/Filament/Widgets/AgileChart.php`) handles negative values
+   - [x] Identify all places where chart minimum values are set
 
 2. [ ] **Architecture Improvements**
    - [ ] Evaluate if a common utility function for calculating chart minimums would be beneficial
    - [ ] Consider creating a trait for charts that need dynamic minimum values
    - [ ] Determine if other charts might benefit from the same fix
 
-3. [ ] **Code Implementation**
-   - [ ] Add a `minValue` property to the StrategyChart class
-   - [ ] Modify the `getDatabaseData()` method to calculate the minimum value based on the data
-   - [ ] Implement logic to round negative values to the nearest -5 (e.g., -3 becomes -5, -7 becomes -10)
-   - [ ] Update the `getOptions()` method to use the calculated minimum value
-   - [ ] Update the AgileChart to handle minimum values with the same rounding logic, to round negative values to the nearest -5 
+3. [x] **Code Implementation**
+   - [x] Add a `minValue` property to the StrategyChart class
+   - [x] Modify the `getDatabaseData()` method to calculate the minimum value based on the data
+   - [x] Implement logic to round negative values to the nearest -5 (e.g., -3 becomes -5, -7 becomes -10)
+   - [x] Update the `getOptions()` method to use the calculated minimum value
+   - [x] Update the AgileChart to handle minimum values with the same rounding logic, to round negative values to the nearest -5 
 
 4. [ ] **Testing**
    - [ ] Create test data that includes negative costs
@@ -28,9 +28,9 @@ The strategy chart currently has a hard-coded minimum of 0. If any costs are bel
    - [ ] Ensure the minimum value is correctly set to the nearest -5
    - [ ] Check that positive-only data still displays correctly
 
-5. [ ] **Documentation**
-   - [ ] Update any relevant documentation about the chart behavior
-   - [ ] Add comments to the code explaining the minimum value calculation
+5. [x] **Documentation**
+   - [x] Update any relevant documentation about the chart behavior
+   - [x] Add comments to the code explaining the minimum value calculation
    - [ ] Document the fix in the project changelog if one exists
 
 6. [ ] **Code Review and Quality Assurance**


### PR DESCRIPTION

Implemented logic to calculate and round minimum y-axis values to the nearest -5 for StrategyChart and AgileChart. Updated `getDatabaseData` and chart options to support negative values for better data visualization. Enhanced documentation for clarity.