### PR TITLE
Update export cost logic and integrate OutgoingOctopus model

### DIFF
--- a/app/Domain/Energy/Models/OctopusExport.php
+++ b/app/Domain/Energy/Models/OctopusExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Energy\Models;
 
+use App\Domain\Strategy\Models\Strategy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -17,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property-read \App\Domain\Energy\Models\AgileImport|null $importCost
  * @property-read \App\Domain\Energy\Models\OctopusImport|null $octopusImport
  * @property-read \App\Domain\Energy\Models\Inverter|null $inverter
+ * @property-read \App\Domain\Strategy\Models\Strategy|null $strategy
  *
  * @method static \Illuminate\Database\Eloquent\Builder|OctopusExport newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|OctopusExport newQuery()
@@ -63,5 +65,10 @@ class OctopusExport extends Model
     public function inverter(): HasOne
     {
         return $this->hasOne(Inverter::class, 'period', 'interval_start');
+    }
+
+    public function strategy(): HasOne
+    {
+        return $this->hasOne(Strategy::class, 'period', 'interval_start');
     }
 }

--- a/app/Domain/Energy/Models/OutgoingOctopus.php
+++ b/app/Domain/Energy/Models/OutgoingOctopus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Domain\Energy\Models;
+
+/**
+ * Current Outgoing Octopus export cost
+ */
+class OutgoingOctopus
+{
+    public const EXPORT_COST = 15;
+}

--- a/app/Filament/Resources/StrategyResource/Widgets/ElectricImportExportChart.php
+++ b/app/Filament/Resources/StrategyResource/Widgets/ElectricImportExportChart.php
@@ -110,7 +110,7 @@ class ElectricImportExportChart extends ChartWidget
         $limit = 48;
 
         $data = OctopusExport::query()
-            ->with(['importCost', 'exportCost', 'octopusImport', 'inverter'])
+            ->with(['importCost', 'strategy', 'octopusImport', 'inverter'])
             ->where(
                 'interval_start',
                 '>=',
@@ -130,7 +130,7 @@ class ElectricImportExportChart extends ChartWidget
 
         $result = [];
         foreach ($data as $exportItem) {
-            $exportValueIncVat = $exportItem->exportCost?->value_inc_vat ?? 0;
+            $exportValueIncVat = $exportItem->strategy?->export_value_inc_vat ?? 0;
             $importValueIncVat = $exportItem->importCost?->value_inc_vat ?? 0;
             $importConsumption = $exportItem->octopusImport?->consumption ?? 0;
             $battery = $exportItem->inverter?->battery_soc ?? 0;

--- a/app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
+++ b/app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\StrategyResource\Widgets;
 
+use App\Domain\Strategy\Models\Strategy;
 use App\Filament\Resources\StrategyResource\Pages\ListStrategies;
 use Filament\Widgets\ChartWidget;
 use Filament\Widgets\Concerns\InteractsWithPageTable;
@@ -106,6 +107,7 @@ class StrategyChart extends ChartWidget
         $importAccumulativeCost = 0;
         $data = [];
 
+        /** @var Strategy $strategy */
         foreach ($tableData as $strategy) {
             $import = $strategy->import_amount + $strategy->battery_charge_amount;
             $export = $strategy->export_amount;

--- a/app/Filament/Widgets/OctopusChart.php
+++ b/app/Filament/Widgets/OctopusChart.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Domain\Energy\Models\OctopusExport;
+use App\Domain\Energy\Models\OutgoingOctopus;
 use Carbon\CarbonPeriod;
 use Filament\Widgets\ChartWidget;
 use Illuminate\Support\Carbon;
@@ -132,8 +133,13 @@ class OctopusChart extends ChartWidget
         $importAccumulativeCost = 0;
 
         $result = [];
+        $eighthJuly2025 = Carbon::createFromFormat('Y-m-d', '2025-07-08', 'UTC');
+
+        /** @var OctopusExport $exportItem */
         foreach ($data as $exportItem) {
-            $exportValueIncVat = $exportItem->exportCost?->value_inc_vat ?? 0;
+            $exportValueIncVat = $exportItem->interval_start->isAfter($eighthJuly2025)
+                ? OutgoingOctopus::EXPORT_COST
+                : $exportItem->exportCost?->value_inc_vat ?? 0;
             $importValueIncVat = $exportItem->importCost?->value_inc_vat ?? 0;
             $importConsumption = $exportItem->octopusImport?->consumption ?? 0;
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         ],
         "cs": "phpcs --standard=PSR12 app tests",
         "cs-fix": "phpcbf --standard=PSR12 app tests",
-        "phpstan": "phpstan analyse",
+        "phpstan": "phpstan analyse --memory-limit 256M",
         "phpstan-baseline": "phpstan analyse --generate-baseline",
         "test": "phpunit",
         "test-coverage": "XDEBUG_MODE=coverage phpunit --coverage-html coverage/html",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,46 +26,6 @@ parameters:
 			path: app/Filament/Resources/StrategyResource/Widgets/CostChart.php
 
 		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$battery_charge_amount\\.$#"
-			count: 1
-			path: app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$battery_percentage_manual\\.$#"
-			count: 1
-			path: app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$export_amount\\.$#"
-			count: 1
-			path: app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$export_value_inc_vat\\.$#"
-			count: 1
-			path: app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$import_amount\\.$#"
-			count: 1
-			path: app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$import_value_inc_vat\\.$#"
-			count: 1
-			path: app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$period\\.$#"
-			count: 1
-			path: app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$strategy_manual\\.$#"
-			count: 1
-			path: app/Filament/Resources/StrategyResource/Widgets/StrategyChart.php
-
-		-
 			message: "#^Call to an undefined method Illuminate\\\\Support\\\\Carbon\\:\\:subdays\\(\\)\\.$#"
 			count: 1
 			path: app/Filament/Widgets/ForecastChart.php

--- a/tests/Feature/Filament/StrategyResourceTest.php
+++ b/tests/Feature/Filament/StrategyResourceTest.php
@@ -35,7 +35,13 @@ class StrategyResourceTest extends TestCase
     public function testCanViewListStrategies(): void
     {
         // Create some strategies
-        Strategy::factory()->count(5)->create();
+        Strategy::factory()->create([
+            'period' => now()->startOfDay()->addHours(2),
+        ]);
+
+        Strategy::factory()->create([
+            'period' => now()->startOfDay()->addHours(3),
+        ]);
 
         // Test the Livewire component
         Livewire::actingAs($this->user)
@@ -83,7 +89,9 @@ class StrategyResourceTest extends TestCase
     public function testCanDeleteStrategy(): void
     {
         // Create a strategy
-        $strategy = Strategy::factory()->create();
+        $strategy = Strategy::factory()->create([
+            'period' => now()->startOfHour(),
+        ]);
 
         // Test the Livewire component for bulk deletion
         Livewire::actingAs($this->user)


### PR DESCRIPTION
- Added `OutgoingOctopus` model with constant `EXPORT_COST`.
- Updated export cost logic to use `OutgoingOctopus::EXPORT_COST` for dates after 8th July 2025.
- Added `strategy` relationship to `OctopusExport` model.
- Refactored related actions and widgets to incorporate updated export cost and relationships.