### PR TITLE
Clamp negative consumption values

### DIFF
--- a/app/Domain/Energy/Imports/InverterImport.php
+++ b/app/Domain/Energy/Imports/InverterImport.php
@@ -81,7 +81,8 @@ class InverterImport implements ToCollection, WithHeadingRow
                     - $firstInPeriod['Total Energy from Grid(kWh)'],
                     consumption: max(
                         0.0,
-                        $lastInPeriod['Today Total Load Consumption(kWh)'] - $firstInPeriod['Today Total Load Consumption(kWh)']
+                        $lastInPeriod['Today Total Load Consumption(kWh)']
+                        - $firstInPeriod['Today Total Load Consumption(kWh)']
                     )
                 );
 

--- a/app/Domain/Energy/Imports/InverterImport.php
+++ b/app/Domain/Energy/Imports/InverterImport.php
@@ -73,13 +73,16 @@ class InverterImport implements ToCollection, WithHeadingRow
                     $lastInPeriod = $collection[$i - 2];
                 }
 
+
                 $energyFlow = new EnergyFlow(
                     yield: $lastInPeriod['Today Yield(kWh)'] - $firstInPeriod['Today Yield(kWh)'],
                     toGrid: $lastInPeriod['Total Energy to Grid(kWh)'] - $firstInPeriod['Total Energy to Grid(kWh)'],
                     fromGrid: $lastInPeriod['Total Energy from Grid(kWh)']
                     - $firstInPeriod['Total Energy from Grid(kWh)'],
-                    consumption: $lastInPeriod['Today Total Load Consumption(kWh)']
-                    - $firstInPeriod['Today Total Load Consumption(kWh)']
+                    consumption: max(
+                        0.0,
+                        $lastInPeriod['Today Total Load Consumption(kWh)'] - $firstInPeriod['Today Total Load Consumption(kWh)']
+                    )
                 );
 
                 $batterySoc = isset($firstInPeriod['Battery SOC(%)'])
@@ -87,7 +90,7 @@ class InverterImport implements ToCollection, WithHeadingRow
                     : null;
 
                 $data[] = [
-                    'period' => $currentPeriod->toDateTimeString(),
+                    'period'      => $currentPeriod->toDateTimeString(),
                     ...$energyFlow->toArray(),
                     'battery_soc' => $batterySoc?->percentage,
                 ];

--- a/app/Domain/Energy/Repositories/EloquentInverterRepository.php
+++ b/app/Domain/Energy/Repositories/EloquentInverterRepository.php
@@ -37,9 +37,13 @@ class EloquentInverterRepository implements InverterRepositoryInterface
             ->get();
 
         return $averageConsumptions->map(function ($item) {
+            $value = (float) $item->value;
+            // Guard against negative averages due to data glitches
+            $value = max(0.0, $value);
+
             return new InverterConsumptionData(
                 time: $item->time,
-                value: (float) $item->value
+                value: $value
             );
         });
     }
@@ -61,9 +65,13 @@ class EloquentInverterRepository implements InverterRepositoryInterface
             ->get();
 
         return $consumptions->map(function ($consumption) {
+            $value = (float) $consumption->consumption;
+            // Guard against any negative readings in the raw data
+            $value = max(0.0, $value);
+
             return new InverterConsumptionData(
                 time: $consumption->period->format('H:i:s'),
-                value: (float) $consumption->consumption
+                value: $value
             );
         });
     }

--- a/app/Domain/Strategy/Models/Strategy.php
+++ b/app/Domain/Strategy/Models/Strategy.php
@@ -148,10 +148,15 @@ class Strategy extends Model
     public function getConsumptionDataValueObject(): ConsumptionData
     {
         if ($this->consumptionDataObject === null) {
+            // Clamp any negative values to 0 to satisfy ConsumptionData invariants and avoid rendering exceptions
+            $lastWeek = $this->attributes['consumption_last_week'] ?? null;
+            $average = $this->attributes['consumption_average'] ?? null;
+            $manual = $this->attributes['consumption_manual'] ?? null;
+
             $this->consumptionDataObject = ConsumptionData::fromArray([
-                'consumption_last_week' => $this->attributes['consumption_last_week'] ?? null,
-                'consumption_average' => $this->attributes['consumption_average'] ?? null,
-                'consumption_manual' => $this->attributes['consumption_manual'] ?? null,
+                'consumption_last_week' => $lastWeek !== null ? max(0.0, (float) $lastWeek) : null,
+                'consumption_average' => $average !== null ? max(0.0, (float) $average) : null,
+                'consumption_manual' => $manual !== null ? max(0.0, (float) $manual) : null,
             ]);
         }
 
@@ -233,11 +238,12 @@ class Strategy extends Model
      */
     public function setConsumptionLastWeekAttribute(?float $value): void
     {
-        $this->attributes['consumption_last_week'] = $value;
+        $clamped = $value !== null ? max(0.0, (float) $value) : null;
+        $this->attributes['consumption_last_week'] = $clamped;
 
         if ($this->consumptionDataObject !== null) {
             $this->consumptionDataObject = new ConsumptionData(
-                lastWeek: $value,
+                lastWeek: $clamped,
                 average: $this->consumptionDataObject->average,
                 manual: $this->consumptionDataObject->manual
             );
@@ -257,12 +263,13 @@ class Strategy extends Model
      */
     public function setConsumptionAverageAttribute(?float $value): void
     {
-        $this->attributes['consumption_average'] = $value;
+        $clamped = $value !== null ? max(0.0, (float) $value) : null;
+        $this->attributes['consumption_average'] = $clamped;
 
         if ($this->consumptionDataObject !== null) {
             $this->consumptionDataObject = new ConsumptionData(
                 lastWeek: $this->consumptionDataObject->lastWeek,
-                average: $value,
+                average: $clamped,
                 manual: $this->consumptionDataObject->manual
             );
         }
@@ -281,13 +288,14 @@ class Strategy extends Model
      */
     public function setConsumptionManualAttribute(?float $value): void
     {
-        $this->attributes['consumption_manual'] = $value;
+        $clamped = $value !== null ? max(0.0, (float) $value) : null;
+        $this->attributes['consumption_manual'] = $clamped;
 
         if ($this->consumptionDataObject !== null) {
             $this->consumptionDataObject = new ConsumptionData(
                 lastWeek: $this->consumptionDataObject->lastWeek,
                 average: $this->consumptionDataObject->average,
-                manual: $value
+                manual: $clamped
             );
         }
     }


### PR DESCRIPTION
Clamp negative consumption values to 0 in `Strategy` and `Inverter` components

- Updated `Strategy` model to enforce non-negative values for consumption-related attributes via clamping.
- Adjusted `InverterImport` and `EloquentInverterRepository` to prevent negative readings in consumption calculations.
- Added comments clarifying clamping logic to avoid invalid data propagation.