### PR TITLE
feat(strategy): update filter to handle 4 PM rollover ⏳

### DIFF
--- a/app/Filament/Resources/StrategyResource.php
+++ b/app/Filament/Resources/StrategyResource.php
@@ -272,7 +272,11 @@ class StrategyResource extends Resource
                             $query->whereBetween('period', [$start, $end]);
                         }
                     })
-                    ->default(now()->format('Y-m-d')),
+                    ->default(
+                        fn() => now('Europe/London') < now('Europe/London')->setTime(16, 0)
+                            ? now('Europe/London')->format('Y-m-d')
+                            : now('Europe/London')->addDay()->format('Y-m-d')
+                    ),
             ], layout: FiltersLayout::AboveContent)
             ->headerActions([
                 GenerateAction::make(),

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -150,6 +150,10 @@ Once the dashboard chart is interactive, also update the smilar chart in strateg
 
 - [x] Fix `CalculateBatteryPercentage` calculate method
 
+### 1.1.11 Update the strategy filter
+
+- [x] Update the strategy filter to display the correct strategy for the current or next day, 4pm to 4pm period.
+
 ## 2. Testing and Quality Assurance
 
 [ ] Foundation and Security (Phase 1 alignment)

--- a/docs/user-requests.md
+++ b/docs/user-requests.md
@@ -97,6 +97,17 @@ Investigate options on how to accurately update the Solis inverter.
 - Current action: Add a task to section 1.1.x of  `docs/tasks.md`
 - Status: Not started
 
+#### Strategy filter
+
+The strategy filter displays the strategy for the current day, after 4pm it needs to display the strategy for the next
+day, by default.
+
+When the user navigates to the strategy page, the strategy filter should automatically update to display the correct
+strategy for the current or next day, 4pm to 4pm period.
+
+- Current action: Add a task to section 1.1.11 of  `docs/tasks.md`
+- Status: Complete
+
 ### Dashboard
 
 #### Make the Agile cost chart interactive

--- a/tests/Feature/Filament/StrategyResourceTest.php
+++ b/tests/Feature/Filament/StrategyResourceTest.php
@@ -21,6 +21,8 @@ class StrategyResourceTest extends TestCase
     {
         parent::setUp();
 
+        Carbon::setTestNow(Carbon::today()->setTime(12, 0, 0));
+
         // Create and authenticate a user using the factory
         $this->user = User::factory()->create([
             'name' => 'Test User',


### PR DESCRIPTION
## Summary

- Updated the strategy filter to display the correct day’s strategy based on a 4 PM to 4 PM period.
- Adjusted tests and added timezone handling to ensure accurate behavior.
