### PR TITLE
Feature/1.1.26 automate the strategy performance

### DIFF
--- a/app/Application/Commands/Energy/ExportOctopusUsageCommand.php
+++ b/app/Application/Commands/Energy/ExportOctopusUsageCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Commands\Energy;
+
+use App\Application\Commands\Contracts\Command;
+
+final class ExportOctopusUsageCommand implements Command
+{
+}

--- a/app/Application/Commands/Energy/ExportOctopusUsageCommandHandler.php
+++ b/app/Application/Commands/Energy/ExportOctopusUsageCommandHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Commands\Energy;
+
+use App\Application\Commands\Contracts\Command;
+use App\Application\Commands\Contracts\CommandHandler;
+use App\Domain\Energy\Actions\OctopusExport as OctopusExportAction;
+use App\Support\Actions\ActionResult;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+use function assert;
+
+final readonly class ExportOctopusUsageCommandHandler implements CommandHandler
+{
+    public function __construct(private OctopusExportAction $action)
+    {
+    }
+
+    public function handle(Command $command): ActionResult
+    {
+        assert($command instanceof ExportOctopusUsageCommand);
+        $start = microtime(true);
+        Log::info('ExportOctopusUsageCommand started');
+        try {
+            $result = $this->action->execute();
+            if (!$result->isSuccess()) {
+                throw new RuntimeException($result->getMessage() ?? 'Octopus usage export failed');
+            }
+            Log::info('ExportOctopusUsageCommand finished', [
+                'success' => true,
+                'ms' => (int) ((microtime(true) - $start) * 1000),
+            ]);
+            return $result;
+        } catch (Throwable $e) {
+            Log::warning('ExportOctopusUsageCommand failed', [
+                'exception' => $e->getMessage(),
+                'ms' => (int) ((microtime(true) - $start) * 1000),
+            ]);
+            return ActionResult::failure($e->getMessage());
+        }
+    }
+}

--- a/app/Application/Commands/Energy/ImportAgileRatesCommandHandler.php
+++ b/app/Application/Commands/Energy/ImportAgileRatesCommandHandler.php
@@ -6,32 +6,38 @@ namespace App\Application\Commands\Energy;
 
 use App\Application\Commands\Contracts\Command;
 use App\Application\Commands\Contracts\CommandHandler;
+use App\Events\AgileRatesUpdated;
 use App\Domain\Energy\Actions\AgileImport as AgileImportAction;
 use App\Support\Actions\ActionResult;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
 
-final class ImportAgileRatesCommandHandler implements CommandHandler
+use function assert;
+
+final readonly class ImportAgileRatesCommandHandler implements CommandHandler
 {
-    public function __construct(private readonly AgileImportAction $action)
+    public function __construct(private AgileImportAction $action)
     {
     }
 
     public function handle(Command $command): ActionResult
     {
-        \assert($command instanceof ImportAgileRatesCommand);
+        assert($command instanceof ImportAgileRatesCommand);
         $start = microtime(true);
         Log::info('ImportAgileRatesCommand started');
         try {
             $result = $this->action->execute();
             if (!$result->isSuccess()) {
-                throw new \RuntimeException($result->getMessage() ?? 'Agile import failed');
+                throw new RuntimeException($result->getMessage() ?? 'Agile import failed');
             }
             Log::info('ImportAgileRatesCommand finished', [
                 'success' => true,
                 'ms' => (int) ((microtime(true) - $start) * 1000),
             ]);
+            AgileRatesUpdated::dispatch();
             return $result;
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             Log::warning('ImportAgileRatesCommand failed', [
                 'exception' => $e->getMessage(),
                 'ms' => (int) ((microtime(true) - $start) * 1000),

--- a/app/Application/Commands/Energy/ImportOctopusUsageCommand.php
+++ b/app/Application/Commands/Energy/ImportOctopusUsageCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Commands\Energy;
+
+use App\Application\Commands\Contracts\Command;
+
+final class ImportOctopusUsageCommand implements Command
+{
+}

--- a/app/Application/Commands/Energy/ImportOctopusUsageCommandHandler.php
+++ b/app/Application/Commands/Energy/ImportOctopusUsageCommandHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Commands\Energy;
+
+use App\Application\Commands\Contracts\Command;
+use App\Application\Commands\Contracts\CommandHandler;
+use App\Domain\Energy\Actions\OctopusImport as OctopusImportAction;
+use App\Support\Actions\ActionResult;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+use function assert;
+
+final readonly class ImportOctopusUsageCommandHandler implements CommandHandler
+{
+    public function __construct(private OctopusImportAction $action)
+    {
+    }
+
+    public function handle(Command $command): ActionResult
+    {
+        assert($command instanceof ImportOctopusUsageCommand);
+        $start = microtime(true);
+        Log::info('ImportOctopusUsageCommand started');
+        try {
+            $result = $this->action->execute();
+            if (!$result->isSuccess()) {
+                throw new RuntimeException($result->getMessage() ?? 'Octopus usage import failed');
+            }
+            Log::info('ImportOctopusUsageCommand finished', [
+                'success' => true,
+                'ms' => (int)((microtime(true) - $start) * 1000),
+            ]);
+            return $result;
+        } catch (Throwable $e) {
+            Log::warning('ImportOctopusUsageCommand failed', [
+                'exception' => $e->getMessage(),
+                'ms' => (int)((microtime(true) - $start) * 1000),
+            ]);
+            return ActionResult::failure($e->getMessage());
+        }
+    }
+}

--- a/app/Console/Commands/Octopus.php
+++ b/app/Console/Commands/Octopus.php
@@ -2,12 +2,13 @@
 
 namespace App\Console\Commands;
 
-use App\Domain\Energy\Actions\AgileExport;
-use App\Domain\Energy\Actions\AgileImport;
-use App\Domain\Energy\Actions\OctopusExport;
-use App\Domain\Energy\Actions\OctopusImport;
+use App\Application\Commands\Bus\CommandBus;
+use App\Application\Commands\Energy\ExportAgileRatesCommand;
+use App\Application\Commands\Energy\ExportOctopusUsageCommand;
+use App\Application\Commands\Energy\ImportAgileRatesCommand;
+use App\Application\Commands\Energy\ImportOctopusUsageCommand;
+use App\Application\Commands\Energy\SyncOctopusAccountCommand;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Log;
 
 class Octopus extends Command
 {
@@ -28,64 +29,27 @@ class Octopus extends Command
     /**
      * Execute the console command.
      */
-    public function handle(
-        OctopusImport $octopusImport,
-        OctopusExport $octopusExport,
-        AgileImport $agileImport,
-        AgileExport $agileExport
-    ) {
+    public function handle(CommandBus $commandBus): void
+    {
         $this->info('Running Octopus action!');
 
-        try {
-            $result = $octopusImport->execute();
-            if ($result->isSuccess()) {
-                $this->info('Octopus import has been fetched!');
-            } else {
-                $this->warn('Octopus import fetch failed: ' . ($result->getMessage() ?? 'unknown error'));
-            }
-        } catch (\Throwable $th) {
-            Log::error('Error running Octopus import action:', ['error message' => $th->getMessage()]);
-            $this->error('Error running Octopus import action:');
-            $this->error($th->getMessage());
-        }
+        $commands = [
+            'Octopus account sync' => new SyncOctopusAccountCommand(),
+            'Octopus usage import' => new ImportOctopusUsageCommand(),
+            'Octopus usage export' => new ExportOctopusUsageCommand(),
+            'Octopus Agile import' => new ImportAgileRatesCommand(),
+            'Octopus Agile export' => new ExportAgileRatesCommand(),
+        ];
 
-        try {
-            $result = $octopusExport->execute();
-            if ($result->isSuccess()) {
-                $this->info('Octopus export has been fetched!');
-            } else {
-                $this->warn('Octopus export fetch failed: ' . ($result->getMessage() ?? 'unknown error'));
-            }
-        } catch (\Throwable $th) {
-            Log::error('Error running Octopus export action:', ['error message' => $th->getMessage()]);
-            $this->error('Error running Octopus export action:');
-            $this->error($th->getMessage());
-        }
+        foreach ($commands as $label => $command) {
+            $this->info("Running $label...");
+            $result = $commandBus->dispatch($command);
 
-        try {
-            $result = $agileImport->execute();
             if ($result->isSuccess()) {
-                $this->info('Octopus Agile import has been fetched!');
+                $this->info("$label successful: " . ($result->getMessage() ?? 'OK'));
             } else {
-                $this->warn('Octopus Agile import fetch failed: ' . ($result->getMessage() ?? 'unknown error'));
+                $this->error("$label failed: " . ($result->getMessage() ?? 'unknown error'));
             }
-        } catch (\Throwable $th) {
-            Log::error('Error running Octopus Agile import action:', ['error message' => $th->getMessage()]);
-            $this->error('Error running Octopus Agile import action:');
-            $this->error($th->getMessage());
-        }
-
-        try {
-            $result = $agileExport->execute();
-            if ($result->isSuccess()) {
-                $this->info('Octopus Agile export has been fetched!');
-            } else {
-                $this->warn('Octopus Agile export fetch failed: ' . ($result->getMessage() ?? 'unknown error'));
-            }
-        } catch (\Throwable $th) {
-            Log::error('Error running Octopus Agile export action:', ['error message' => $th->getMessage()]);
-            $this->error('Error running Octopus Agile export action:');
-            $this->error($th->getMessage());
         }
     }
 }

--- a/app/Events/AgileRatesUpdated.php
+++ b/app/Events/AgileRatesUpdated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class AgileRatesUpdated
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct()
+    {
+    }
+}

--- a/app/Listeners/TriggerStrategyGeneration.php
+++ b/app/Listeners/TriggerStrategyGeneration.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Application\Commands\Bus\CommandBus;
+use App\Application\Commands\Strategy\GenerateStrategyCommand;
+use App\Events\AgileRatesUpdated;
+use App\Domain\Energy\Models\AgileImport;
+use Illuminate\Support\Carbon;
+
+class TriggerStrategyGeneration
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct(private readonly CommandBus $commandBus)
+    {
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(AgileRatesUpdated $event): void
+    {
+        $today4pm = Carbon::today('Europe/London')->setHour(16)->setMinute(0)->setSecond(0);
+        $tomorrow4pm = $today4pm->copy()->addDay();
+
+        // Check if we have data for today's 4pm period (16:00 today to 16:00 tomorrow)
+        if ($this->hasDataForPeriod($today4pm)) {
+            $this->commandBus->dispatch(new GenerateStrategyCommand($today4pm->format('Y-m-d H:i')));
+        }
+
+        // Check if we have data for tomorrow's 4pm period (16:00 tomorrow to 16:00 the day after)
+        if ($this->hasDataForPeriod($tomorrow4pm)) {
+            $this->commandBus->dispatch(new GenerateStrategyCommand($tomorrow4pm->format('Y-m-d H:i')));
+        }
+    }
+
+    private function hasDataForPeriod(Carbon $start): bool
+    {
+        $end = $start->copy()->addDay();
+
+        // Strategy needs data for the full 24h period.
+        // Agile rates are 30 min intervals.
+        // We check if the latest valid_to in DB is at least the end of the period.
+        $latest = AgileImport::query()->latest('valid_to')->value('valid_to');
+
+        if (!$latest) {
+            return false;
+        }
+
+        return Carbon::parse($latest)->greaterThanOrEqualTo($end);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,8 +6,12 @@ use App\Application\Commands\Bus\CommandBus;
 use App\Application\Commands\Bus\SimpleCommandBus;
 use App\Application\Commands\Energy\ExportAgileRatesCommand;
 use App\Application\Commands\Energy\ExportAgileRatesCommandHandler;
+use App\Application\Commands\Energy\ExportOctopusUsageCommand;
+use App\Application\Commands\Energy\ExportOctopusUsageCommandHandler;
 use App\Application\Commands\Energy\ImportAgileRatesCommand;
 use App\Application\Commands\Energy\ImportAgileRatesCommandHandler;
+use App\Application\Commands\Energy\ImportOctopusUsageCommand;
+use App\Application\Commands\Energy\ImportOctopusUsageCommandHandler;
 use App\Application\Commands\Energy\SyncOctopusAccountCommand;
 use App\Application\Commands\Energy\SyncOctopusAccountCommandHandler;
 use App\Application\Commands\Forecasting\RefreshForecastsCommand;
@@ -26,6 +30,8 @@ use App\Application\Commands\Strategy\GetInverterDayDataCommand;
 use App\Application\Commands\Strategy\GetInverterDayDataHandler;
 use App\Application\Commands\Strategy\RecalculateStrategyCostsCommand;
 use App\Application\Commands\Strategy\RecalculateStrategyCostsCommandHandler;
+use App\Events\AgileRatesUpdated;
+use App\Listeners\TriggerStrategyGeneration;
 use App\Domain\Forecasting\Events\SolcastAllowanceReset;
 use App\Domain\Forecasting\Events\SolcastRateLimited;
 use App\Domain\Forecasting\Events\SolcastRequestAttempted;
@@ -39,6 +45,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
+use Throwable;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -55,6 +62,8 @@ class AppServiceProvider extends ServiceProvider
             $bus->register(GenerateStrategyCommand::class, GenerateStrategyCommandHandler::class);
             $bus->register(ImportAgileRatesCommand::class, ImportAgileRatesCommandHandler::class);
             $bus->register(ExportAgileRatesCommand::class, ExportAgileRatesCommandHandler::class);
+            $bus->register(ImportOctopusUsageCommand::class, ImportOctopusUsageCommandHandler::class);
+            $bus->register(ExportOctopusUsageCommand::class, ExportOctopusUsageCommandHandler::class);
             $bus->register(SyncOctopusAccountCommand::class, SyncOctopusAccountCommandHandler::class);
             $bus->register(CalculateBatteryCommand::class, CalculateBatteryCommandHandler::class);
             $bus->register(CopyConsumptionWeekAgoCommand::class, CopyConsumptionWeekAgoCommandHandler::class);
@@ -79,9 +88,9 @@ class AppServiceProvider extends ServiceProvider
             try {
                 Log::info('solcast.attempted', [
                     'endpoint' => $e->endpoint->value,
-                    'at' => (string) $e->at,
+                    'at' => (string)$e->at,
                 ]);
-                if ((bool) config('solcast.allowance.log_to_db', false)) {
+                if (config('solcast.allowance.log_to_db', false)) {
                     SolcastAllowanceLog::create([
                         'event_type' => 'attempted',
                         'endpoint' => $e->endpoint->value,
@@ -89,7 +98,7 @@ class AppServiceProvider extends ServiceProvider
                         'created_at' => $e->at,
                     ]);
                 }
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 // no-op
             }
         });
@@ -97,9 +106,9 @@ class AppServiceProvider extends ServiceProvider
             try {
                 Log::info('solcast.succeeded', [
                     'endpoint' => $e->endpoint->value,
-                    'at' => (string) $e->at,
+                    'at' => (string)$e->at,
                 ]);
-                if ((bool) config('solcast.allowance.log_to_db', false)) {
+                if (config('solcast.allowance.log_to_db', false)) {
                     SolcastAllowanceLog::create([
                         'event_type' => 'succeeded',
                         'endpoint' => $e->endpoint->value,
@@ -107,7 +116,7 @@ class AppServiceProvider extends ServiceProvider
                         'created_at' => $e->at,
                     ]);
                 }
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 // no-op
             }
         });
@@ -117,9 +126,9 @@ class AppServiceProvider extends ServiceProvider
                     'endpoint' => $e->endpoint->value,
                     'reason' => $e->reason,
                     'nextEligibleAt' => $e->nextEligibleAt?->toIso8601String(),
-                    'at' => (string) $e->at,
+                    'at' => (string)$e->at,
                 ]);
-                if ((bool) config('solcast.allowance.log_to_db', false)) {
+                if (config('solcast.allowance.log_to_db', false)) {
                     SolcastAllowanceLog::create([
                         'event_type' => 'skipped',
                         'endpoint' => $e->endpoint->value,
@@ -129,7 +138,7 @@ class AppServiceProvider extends ServiceProvider
                         'created_at' => $e->at,
                     ]);
                 }
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 // no-op
             }
         });
@@ -139,9 +148,9 @@ class AppServiceProvider extends ServiceProvider
                     'endpoint' => $e->endpoint->value,
                     'status' => $e->status,
                     'backoffUntil' => $e->backoffUntil->toIso8601String(),
-                    'at' => (string) $e->at,
+                    'at' => (string)$e->at,
                 ]);
-                if ((bool) config('solcast.allowance.log_to_db', false)) {
+                if (config('solcast.allowance.log_to_db', false)) {
                     SolcastAllowanceLog::create([
                         'event_type' => 'rate_limited',
                         'endpoint' => $e->endpoint->value,
@@ -151,7 +160,7 @@ class AppServiceProvider extends ServiceProvider
                         'created_at' => $e->at,
                     ]);
                 }
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 // no-op
             }
         });
@@ -161,7 +170,7 @@ class AppServiceProvider extends ServiceProvider
                     'dayKey' => $e->dayKey,
                     'resetAt' => $e->resetAt->toIso8601String(),
                 ]);
-                if ((bool) config('solcast.allowance.log_to_db', false)) {
+                if (config('solcast.allowance.log_to_db', false)) {
                     SolcastAllowanceLog::create([
                         'event_type' => 'allowance_reset',
                         'day_key' => $e->dayKey,
@@ -169,14 +178,14 @@ class AppServiceProvider extends ServiceProvider
                         'payload' => null,
                     ]);
                 }
-            } catch (\Throwable) {
+            } catch (Throwable) {
                 // no-op
             }
         });
 
         // Local-only lightweight SQL profiling toggle.
         // Enable by setting PERF_PROFILE=true in .env when APP_ENV=local or testing.
-        if (app()->environment(['local', 'testing']) && (bool) config('perf.profile', false)) {
+        if (app()->environment(['local', 'testing']) && config('perf.profile', false)) {
             DB::listen(static function (QueryExecuted $query): void {
                 try {
                     Log::debug('sql', [
@@ -185,10 +194,15 @@ class AppServiceProvider extends ServiceProvider
                         'time_ms' => $query->time,
                         'connection' => $query->connectionName,
                     ]);
-                } catch (\Throwable $e) {
+                } catch (Throwable) {
                     // Swallow any logging errors to avoid impacting app behavior during profiling
                 }
             });
         }
+
+        Event::listen(
+            AgileRatesUpdated::class,
+            TriggerStrategyGeneration::class,
+        );
     }
 }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -196,11 +196,13 @@ Once the dashboard chart is interactive, also update the similar chart in strate
 ### 1.1.18 Get inverter data via Solis API *
 
 - POC implemented (simplistic first-second delta); full implementation in progress
-  * Parse full API array: sort timeStr (Carbon UTC), bucket to 48x 30min periods (00:00-23:30), compute cumulative deltas (eToday/grid*/homeLoad deltas → yield/from_grid/to_grid/consumption), clamp negatives=0 like Excel, battery_soc avg/first per bucket
-  * Handle empty/short data/HTTP timeout: log warning, return []
-  * Update unit test: multipoint mock → multiple bucketed records
-  * Feature test: command mock → assert Inverter::count() increases N
-  * Repo: upsertFromSolisData guards (validate periods sequential, floats)
+    * Parse full API array: sort timeStr (Carbon UTC), bucket to 48x 30min periods (00:00-23:30), compute cumulative
+      deltas (eToday/grid*/homeLoad deltas → yield/from_grid/to_grid/consumption), clamp negatives=0 like Excel,
+      battery_soc avg/first per bucket
+    * Handle empty/short data/HTTP timeout: log warning, return []
+    * Update unit test: multipoint mock → multiple bucketed records
+    * Feature test: command mock → assert Inverter::count() increases N
+    * Repo: upsertFromSolisData guards (validate periods sequential, floats)
 - Reuse auth from existing InverterListAction (app/Domain/Solis/Actions) ✓
 - New SolisInverterDayDataAction -> array records (not VO array) ✓
 - Update EloquentInverterRepository::upsertFromSolisData(array $data) ✓
@@ -227,7 +229,8 @@ Once the dashboard chart is interactive, also update the similar chart in strate
     - Between 8th July 2025 and 1st March 2026: 15p/kWh.
     - From 1st March 2026: 12p/kWh.
 - [x] Update `app/Filament/Widgets/OctopusChart.php` to use the new `getRate` method instead of the constant.
-- [x] Update `app/Domain/Strategy/Actions/GenerateStrategyAction.php` and its dependencies (like `StrategyCostCalculator`)
+- [x] Update `app/Domain/Strategy/Actions/GenerateStrategyAction.php` and its dependencies (like
+  `StrategyCostCalculator`)
   to use the new `getRate` method to ensure correct strategy and cost calculations.
 - [x] Add unit tests for `OutgoingOctopus::getRate` to verify the correct rate is returned for different dates.
 - [x] Verify that the Octopus chart and strategy generation still work as expected and use the correct rates.
@@ -265,6 +268,22 @@ Once the dashboard chart is interactive, also update the similar chart in strate
 - [x] Render the strategy page first, then run any pending calculations.
 - [x] Remove `StrategyOverview` widgets from `StrategyResource`.
 - [x] Update `CalculateBatteryAction` to handle asynchronous execution or provide better UI feedback.
+
+### 1.1.26 Automate the strategy performance
+
+- [x] Use TDD to automate the Agile costs update and strategy generation.
+    - [x] Create and checkout a new git branch `feature/1.1.26-automate-the-strategy-performance`
+    - [x] Create an event `AgileRatesUpdated` that is dispatched by `ImportAgileRatesCommandHandler` upon successful
+      completion.
+    - [x] Create a listener `TriggerStrategyGeneration` that listens for `AgileRatesUpdated` and dispatches
+      `GenerateStrategyCommand` for the relevant period(s).
+    - [x] Refactor the `app:octopus` artisan command (`app/Console/Commands/Octopus.php`) to dispatch
+      `ImportAgileRatesCommand` and other relevant commands instead of calling actions directly.
+    - [x] Update `ImportAgileRatesCommandHandler` to dispatch the `AgileRatesUpdated` event.
+    - [x] Register the event and listener in `AppServiceProvider` or a dedicated EventServiceProvider.
+    - [x] Add unit tests for the event dispatching in the handler and for the listener's logic.
+    - [x] Add a feature test for the `app:octopus` command ensuring it initiates the full flow via the CommandBus.
+    - [x] Ensure all tests pass with `composer all`.
 
 ## 1.2 Foundation and Security (Phase 1 alignment)
 

--- a/docs/user-requests.md
+++ b/docs/user-requests.md
@@ -139,7 +139,7 @@ The app is now running on a low-end server, the strategy calculation is taking a
 button should be disabled until the calculation is complete.
 
 Clicking the calculate battery button should be disabled until the calculation is complete. It should also display a
-progress bar to indicate the progress of the calculation. 
+progress bar to indicate the progress of the calculation.
 
 If possible, make the calculation faster. If possible, run the calculation in the background.
 
@@ -148,12 +148,36 @@ On page load, the page should render, then run any pending calculations.
 The `StrategyOverview` widgets are not required, they can be removed.
 
 Thought on indexing the strategy, inverter, forecast, AgileImport, and AgileExport:
+
 - are the dates `valid_from`, `period`, `period_end` related to the strategy indexed?
 - should the dates be converted into an integer? e.g. 2025-04-01 19:00 becomes 202504011900, would this be more
   efficient to index the date as an integer?
 
-- Current action: Add a task to section 1.1.x of  `docs/tasks.md`
-- Status: Not started
+- Current action: Add a task to section 1.1.25 of  `docs/tasks.md`
+- Status: Complete
+
+#### Automate the strategy performance
+
+The performance has improved on the strategy page. I would now like to automate the process using a CRON job, which will
+need to call an artisan command to update the agile costs, and once updated, run the strategy generator.
+
+Useful files:
+
+- `app/Filament/Widgets/AgileChart.php` - existing chart, see `updateAgileImport()` method, which calls
+  `ImportAgileRatesCommand()`
+- `app/Application/Commands/Energy/ImportAgileRatesCommandHandler.php` handler for the command.
+- `app/Domain/Energy/Actions/AgileImport.php` action which calls the API and updates the database.
+- `app/Application/Commands/Strategy/GenerateStrategyCommand.php` current strategy command.
+- `app/Application/Commands/Strategy/GenerateStrategyCommandHandler.php` current strategy handler.
+- `app/Console/Commands/Octopus.php` current octopus command, including cost and usage API calls.
+
+I would recommend a listener to be configured for a successful run of the current job, and when a new day of costs has
+been created, a separate listener would trigger the strategy command.
+
+Looking at the handler, a listener could be configured to trigger the strategy command on `ActionResult::success`
+
+- Current action: Add a task to section 1.1.26 of  `docs/tasks.md`
+- Status: Complete
 
 ### Dashboard
 
@@ -169,9 +193,11 @@ Thought on indexing the strategy, inverter, forecast, AgileImport, and AgileExpo
 
 ## Inverter
 
-When view in the strategy resource, I can see some missing inverted data. It is challenging to identify which days have
-missing data. I would like a new inverter page or resource to display a chart, showing the count of inverted data per
-day for a given month. Most days will show 48 periods. The resource or page should have a filter to switch to a date with
+When viewed in the strategy resource, I can see some missing inverted data. It is challenging to identify which days
+have
+missing data. I would like a new inverter page or resource to display a chart showing the count of inverted data per
+day for a given month. Most days will show 48 periods. The resource or page should have a filter to switch to a date
+with
 missing data, e.g. a date with the number of periods filled in less than 48. And have a button to trigger the action via
 the command to download that today's inverter data. The command`GetInverterDayDataCommand`and action
 `SolisInverterDayDataAction` already exist, to download data for a given day. the command can currently be run via an

--- a/tests/Feature/Console/Commands/OctopusCommandTest.php
+++ b/tests/Feature/Console/Commands/OctopusCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Application\Commands\Bus\CommandBus;
+use App\Application\Commands\Energy\ExportAgileRatesCommand;
+use App\Application\Commands\Energy\ExportOctopusUsageCommand;
+use App\Application\Commands\Energy\ImportAgileRatesCommand;
+use App\Application\Commands\Energy\ImportOctopusUsageCommand;
+use App\Application\Commands\Energy\SyncOctopusAccountCommand;
+use App\Events\AgileRatesUpdated;
+use App\Support\Actions\ActionResult;
+use Illuminate\Support\Facades\Event;
+use Mockery as m;
+use Tests\TestCase;
+
+final class OctopusCommandTest extends TestCase
+{
+    public function testItDispatchesAllExpectedCommands(): void
+    {
+        // We use Event::fake() to check if AgileRatesUpdated is dispatched later
+        Event::fake([AgileRatesUpdated::class]);
+
+        // We can't easily mock the CommandBus and run the command at the same time
+        // because the CommandBus is resolved from the container.
+        $bus = m::mock(CommandBus::class);
+        $this->app->instance(CommandBus::class, $bus);
+
+        $successResult = ActionResult::success();
+
+        $bus->shouldReceive('dispatch')
+            ->with(m::type(SyncOctopusAccountCommand::class))
+            ->once()
+            ->andReturn($successResult);
+
+        $bus->shouldReceive('dispatch')
+            ->with(m::type(ImportOctopusUsageCommand::class))
+            ->once()
+            ->andReturn($successResult);
+
+        $bus->shouldReceive('dispatch')
+            ->with(m::type(ExportOctopusUsageCommand::class))
+            ->once()
+            ->andReturn($successResult);
+
+        $bus->shouldReceive('dispatch')
+            ->with(m::type(ImportAgileRatesCommand::class))
+            ->once()
+            ->andReturn($successResult);
+
+        $bus->shouldReceive('dispatch')
+            ->with(m::type(ExportAgileRatesCommand::class))
+            ->once()
+            ->andReturn($successResult);
+
+        $this->artisan('app:octopus')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/Console/Commands/OctopusTest.php
+++ b/tests/Feature/Console/Commands/OctopusTest.php
@@ -2,13 +2,15 @@
 
 namespace Tests\Feature\Console\Commands;
 
-use App\Console\Commands\Octopus as OctopusCommand;
-use App\Domain\Energy\Actions\AgileExport;
-use App\Domain\Energy\Actions\AgileImport;
-use App\Domain\Energy\Actions\OctopusExport;
-use App\Domain\Energy\Actions\OctopusImport;
+use App\Application\Commands\Bus\CommandBus;
+use App\Application\Commands\Energy\ExportAgileRatesCommand;
+use App\Application\Commands\Energy\ExportOctopusUsageCommand;
+use App\Application\Commands\Energy\ImportAgileRatesCommand;
+use App\Application\Commands\Energy\ImportOctopusUsageCommand;
+use App\Application\Commands\Energy\SyncOctopusAccountCommand;
 use App\Support\Actions\ActionResult;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery as m;
 use Tests\TestCase;
 
 class OctopusTest extends TestCase
@@ -17,42 +19,41 @@ class OctopusTest extends TestCase
 
     public function testOctopusCommandRunsAllActionsAndOutputsMessages(): void
     {
-        // Bind fakes that return success without doing anything
-        $this->app->instance(OctopusImport::class, new class extends OctopusImport
-        {
-            public function execute(): ActionResult
-            {
-                return ActionResult::success();
-            }
-        });
-        $this->app->instance(OctopusExport::class, new class extends OctopusExport
-        {
-            public function execute(): ActionResult
-            {
-                return ActionResult::success();
-            }
-        });
-        $this->app->instance(AgileImport::class, new class extends AgileImport
-        {
-            public function execute(): ActionResult
-            {
-                return ActionResult::success();
-            }
-        });
-        $this->app->instance(AgileExport::class, new class extends AgileExport
-        {
-            public function execute(): ActionResult
-            {
-                return ActionResult::success();
-            }
-        });
+        $commandBus = m::mock(CommandBus::class);
+        $this->app->instance(CommandBus::class, $commandBus);
 
-        $this->artisan((new OctopusCommand())->getName())
+        $commandBus->shouldReceive('dispatch')
+            ->with(m::type(SyncOctopusAccountCommand::class))
+            ->once()
+            ->andReturn(ActionResult::success(null, 'Octopus account synced'));
+
+        $commandBus->shouldReceive('dispatch')
+            ->with(m::type(ImportOctopusUsageCommand::class))
+            ->once()
+            ->andReturn(ActionResult::success(null, 'Octopus usage imported'));
+
+        $commandBus->shouldReceive('dispatch')
+            ->with(m::type(ExportOctopusUsageCommand::class))
+            ->once()
+            ->andReturn(ActionResult::success(null, 'Octopus usage exported'));
+
+        $commandBus->shouldReceive('dispatch')
+            ->with(m::type(ImportAgileRatesCommand::class))
+            ->once()
+            ->andReturn(ActionResult::success(null, 'Octopus Agile import successful'));
+
+        $commandBus->shouldReceive('dispatch')
+            ->with(m::type(ExportAgileRatesCommand::class))
+            ->once()
+            ->andReturn(ActionResult::success(null, 'Octopus Agile export successful'));
+
+        $this->artisan('app:octopus')
             ->expectsOutputToContain('Running Octopus action!')
-            ->expectsOutputToContain('Octopus import has been fetched!')
-            ->expectsOutputToContain('Octopus export has been fetched!')
-            ->expectsOutputToContain('Octopus Agile import has been fetched!')
-            ->expectsOutputToContain('Octopus Agile export has been fetched!')
+            ->expectsOutputToContain('Octopus account sync successful: Octopus account synced')
+            ->expectsOutputToContain('Octopus usage import successful: Octopus usage imported')
+            ->expectsOutputToContain('Octopus usage export successful: Octopus usage exported')
+            ->expectsOutputToContain('Octopus Agile import successful: Octopus Agile import successful')
+            ->expectsOutputToContain('Octopus Agile export successful: Octopus Agile export successful')
             ->assertSuccessful();
     }
 }

--- a/tests/Feature/Listeners/TriggerStrategyGenerationTest.php
+++ b/tests/Feature/Listeners/TriggerStrategyGenerationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Listeners;
+
+use App\Application\Commands\Bus\CommandBus;
+use App\Application\Commands\Strategy\GenerateStrategyCommand;
+use App\Domain\Energy\Models\AgileImport;
+use App\Events\AgileRatesUpdated;
+use App\Listeners\TriggerStrategyGeneration;
+use App\Support\Actions\ActionResult;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Mockery as m;
+use Tests\TestCase;
+
+final class TriggerStrategyGenerationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testItDispatchesGenerateStrategyCommandsWhenDataIsAvailable(): void
+    {
+        Carbon::setTestNow('2026-04-16 17:00:00'); // Thursday 5pm
+
+        /** @var m\MockInterface&CommandBus $commandBus */
+        $commandBus = m::mock(CommandBus::class);
+
+        // Expect two dispatches: today 4pm and tomorrow 4pm
+        $commandBus->shouldReceive('dispatch')
+            ->with(m::on(fn($command) => $command instanceof GenerateStrategyCommand
+                && $command->period === '2026-04-16 16:00'))
+            ->once()
+            ->andReturn(ActionResult::success());
+
+        $commandBus->shouldReceive('dispatch')
+            ->with(m::on(fn($command) => $command instanceof GenerateStrategyCommand
+                && $command->period === '2026-04-17 16:00'))
+            ->once()
+            ->andReturn(ActionResult::success());
+
+        // Seed AgileImport to have data until tomorrow 4pm + 24h = 18th 4pm
+        AgileImport::factory()->create(['valid_to' => '2026-04-18 16:00:00']);
+
+        $listener = new TriggerStrategyGeneration($commandBus);
+        $listener->handle(new AgileRatesUpdated());
+    }
+
+    public function testItOnlyDispatchesTodayWhenTomorrowDataIsMissing(): void
+    {
+        Carbon::setTestNow('2026-04-16 17:00:00'); // Thursday 5pm
+
+        /** @var m\MockInterface&CommandBus $commandBus */
+        $commandBus = m::mock(CommandBus::class);
+
+        // Expect one dispatch: today 4pm
+        $commandBus->shouldReceive('dispatch')
+            ->with(m::on(fn($command) => $command instanceof GenerateStrategyCommand
+                && $command->period === '2026-04-16 16:00'))
+            ->once()
+            ->andReturn(ActionResult::success());
+
+        $commandBus->shouldNotReceive('dispatch')
+            ->with(m::on(fn($command) => $command instanceof GenerateStrategyCommand
+                && $command->period === '2026-04-17 16:00'));
+
+        // Seed AgileImport to have data only until 17th 4pm
+        AgileImport::factory()->create(['valid_to' => '2026-04-17 16:00:00']);
+
+        $listener = new TriggerStrategyGeneration($commandBus);
+        $listener->handle(new AgileRatesUpdated());
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/Application/Commands/ImportAgileRatesCommandHandlerTest.php
+++ b/tests/Unit/Application/Commands/ImportAgileRatesCommandHandlerTest.php
@@ -6,15 +6,19 @@ namespace Tests\Unit\Application\Commands;
 
 use App\Application\Commands\Energy\ImportAgileRatesCommand;
 use App\Application\Commands\Energy\ImportAgileRatesCommandHandler;
+use App\Events\AgileRatesUpdated;
 use App\Domain\Energy\Actions\AgileImport as AgileImportAction;
 use App\Support\Actions\ActionResult;
+use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use Tests\TestCase;
 
 final class ImportAgileRatesCommandHandlerTest extends TestCase
 {
-    public function testSuccessPathDelegatesToActionExecute(): void
+    public function testSuccessPathDelegatesToActionExecuteAndDispatchesEvent(): void
     {
+        Event::fake();
+
         /** @var m\MockInterface&AgileImportAction $action */
         $action = m::mock(AgileImportAction::class);
         $action->shouldReceive('execute')
@@ -26,10 +30,14 @@ final class ImportAgileRatesCommandHandlerTest extends TestCase
 
         $this->assertTrue($result->isSuccess());
         $this->assertSame('Agile import updated', $result->getMessage());
+
+        Event::assertDispatched(AgileRatesUpdated::class);
     }
 
-    public function testFailureIsWrappedAndReturned(): void
+    public function testFailureIsWrappedAndReturnedAndDoesNotDispatchEvent(): void
     {
+        Event::fake();
+
         /** @var m\MockInterface&AgileImportAction $action */
         $action = m::mock(AgileImportAction::class);
         // @phpstan-ignore-next-line
@@ -40,5 +48,7 @@ final class ImportAgileRatesCommandHandlerTest extends TestCase
 
         $this->assertFalse($result->isSuccess());
         $this->assertSame('boom', $result->getMessage());
+
+        Event::assertNotDispatched(AgileRatesUpdated::class);
     }
 }


### PR DESCRIPTION
refactor(octopus): use command bus for actions 🚀

- Replaced direct action calls in the `app:octopus` command with `CommandBus` dispatching for better encapsulation and maintainability.
- Updated tests and refactored dependencies to align with the new structure.

feat(commands): add octopus usage sync ⚙️

- Introduced commands and handlers for exporting and importing Octopus usage data.
- Added event listeners and tests for automated strategy generation on Agile rate updates.